### PR TITLE
SearchToolbar: Don't set shortcuts from UI file

### DIFF
--- a/src/lib/webtab/searchtoolbar.cpp
+++ b/src/lib/webtab/searchtoolbar.cpp
@@ -33,9 +33,11 @@ SearchToolBar::SearchToolBar(WebView* view, QWidget* parent)
     setAttribute(Qt::WA_DeleteOnClose);
     ui->setupUi(widget());
 
-    ui->closeButton->setIcon(IconProvider::standardIcon(QStyle::SP_DialogCloseButton));
-    ui->next->setIcon(IconProvider::standardIcon(QStyle::SP_ArrowDown));
-    ui->previous->setIcon(IconProvider::standardIcon(QStyle::SP_ArrowUp));
+    ui->closeButton->setIcon(IconProvider::instance()->standardIcon(QStyle::SP_DialogCloseButton));
+    ui->next->setIcon(IconProvider::instance()->standardIcon(QStyle::SP_ArrowDown));
+    ui->next->setShortcut(QKeySequence("Ctrl+G"));
+    ui->previous->setIcon(IconProvider::instance()->standardIcon(QStyle::SP_ArrowUp));
+    ui->previous->setShortcut(QKeySequence("Ctrl+Shift+G"));
 
     connect(ui->closeButton, SIGNAL(clicked()), this, SLOT(hide()));
     connect(ui->lineEdit, SIGNAL(textChanged(QString)), this, SLOT(findNext()));

--- a/src/lib/webtab/searchtoolbar.ui
+++ b/src/lib/webtab/searchtoolbar.ui
@@ -64,9 +64,6 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="shortcut">
-      <string notr="true">Ctrl+Shift+G</string>
-     </property>
      <property name="autoRaise">
       <bool>true</bool>
      </property>
@@ -79,9 +76,6 @@
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
-     </property>
-     <property name="shortcut">
-      <string notr="true">Ctrl+G</string>
      </property>
      <property name="autoRaise">
       <bool>true</bool>


### PR DESCRIPTION
Fixes build with Qt 5.10